### PR TITLE
universal-watermark-disabler: Fix hardcoded `checkver.regex`

### DIFF
--- a/bucket/universal-watermark-disabler.json
+++ b/bucket/universal-watermark-disabler.json
@@ -13,7 +13,6 @@
         ]
     ],
     "checkver": {
-        "url": "https://winaero.com/download-universal-watermark-disabler",
         "regex": ">Universal Watermark Disabler ([\\d.]+)<"
     },
     "autoupdate": {

--- a/bucket/universal-watermark-disabler.json
+++ b/bucket/universal-watermark-disabler.json
@@ -14,8 +14,7 @@
     ],
     "checkver": {
         "url": "https://winaero.com/download-universal-watermark-disabler",
-        "regex": "<span id=\"Universal_Watermark_Disabler_1006\">Universal\\sWatermark\\sDisabler\\s(?<ver>[\\d.]+)</span>",
-        "replace": "${ver}"
+        "regex": ">Universal Watermark Disabler ([\\d.]+)<"
     },
     "autoupdate": {
         "url": "https://winaero.com/downloads/uwd.zip"


### PR DESCRIPTION
The version without `.`s was literally hardcoded in the `checkver.regex`

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).