### PR TITLE
qaac-qtfiles: Update to maintained fork

### DIFF
--- a/bucket/qaac-qtfiles.json
+++ b/bucket/qaac-qtfiles.json
@@ -1,71 +1,43 @@
 {
-    "version": "12.10.11",
+    "version": "12.12.9.4",
     "description": "Use qaac without installing iTunes",
-    "homepage": "https://github.com/AnimMouse/QTFiles",
+    "homepage": "https://github.com/K3V1991/QuickTime-Files-for-qaac",
     "license": "MPL-2.0",
-    "depends": "muggle/qaac",
     "architecture": {
         "64bit": {
-            "url": [
-                "https://github.com/AnimMouse/QTFiles/releases/download/v12.10.11/QTfiles64.7z",
-                "https://github.com/AnimMouse/QTFiles/releases/download/v12.10.11/QTfiles64-msvc.7z"
-            ],
-            "hash": [
-                "32fcd058936410f7eabd3b55a8931bce5f45bb7892d6a2c65387820daca52f58",
-                "740977b8bcd259fe8e92d3e5c2585337f5ad2c2641f94bbda033bf9c8e8b6cdd"
-            ],
-            "installer": {
-                "script": [
-                    "$qaacDir = $(appdir qaac $global)",
-                    "if (Test-Path \"$qaacDir\") {",
-                    "    Get-ChildItem -Path \"$qaacDir\\current\" -Filter \"QTFiles*\" | Remove-Item -Force -Recurse",
-                    "    New-Item \"$qaacDir\\current\\QTFiles64\" -ItemType Junction -Target \"$dir\" | Out-Null",
-                    "}"
-                ]
-            }
+            "url": "https://github.com/K3V1991/QuickTime-Files-for-qaac/releases/download/v12.12.9.4/QT_v12.12.9.4-x64.zip",
+            "hash": "cd5e7407d66494125fe5f451b9f241ac2a468011280b6ac3471360e3486fe44c",
+            "extract_dir": "QT v12.12.9.4 (x64)"
         },
         "32bit": {
-            "url": [
-                "https://github.com/AnimMouse/QTFiles/releases/download/v12.10.11/QTfiles.7z",
-                "https://github.com/AnimMouse/QTFiles/releases/download/v12.10.11/QTfiles-msvc.7z"
-            ],
-            "hash": [
-                "c6c582fe1af4e0c2b1eb7c141ad929a81f14d123aedd3b16df8226c104fb3028",
-                "ac73af12e56b054c09e4aa45565116abc84725cc54ed3c2e05bd3fcaf8dc8358"
-            ],
-            "installer": {
-                "script": [
-                    "$qaacDir = $(appdir qaac $global)",
-                    "if (Test-Path \"$qaacDir\") {",
-                    "    Get-ChildItem -Path \"$qaacDir\\current\" -Filter \"QTFiles*\" | Remove-Item -Force -Recurse",
-                    "    New-Item \"$qaacDir\\current\\QTFiles\" -ItemType Junction -Target \"$dir\" | Out-Null",
-                    "}"
-                ]
-            }
+            "url": "https://github.com/K3V1991/QuickTime-Files-for-qaac/releases/download/v12.12.9.4/QT_v12.12.9.4-x86.zip",
+            "hash": "12a29562ce68db0a096d9161225bf0257202f7ff834d9eb97b4cb8a0f96e334d",
+            "extract_dir": "QT v12.12.9.4 (x86)"
         }
     },
-    "uninstaller": {
-        "script": [
-            "$qaacDir = $(appdir qaac $global)",
-            "if (Test-Path \"$qaacDir\") {",
-            "    Get-ChildItem -Path \"$qaacDir\\current\" -Filter \"QTFiles*\" | Remove-Item -Force -Recurse",
-            "}"
-        ]
-    },
+    "pre_install": [
+        "$qaacDir = $(appdir qaac $global)",
+        "if (Test-Path \"$qaacDir\") {",
+        "    Get-ChildItem -Path \"$qaacDir\\current\" -Filter \"QTFiles*\" | Remove-Item -Force -Recurse",
+        "    New-Item \"$qaacDir\\current\\QTFiles\" -ItemType Junction -Target \"$dir\" | Out-Null",
+        "}"
+    ],
+    "pre_uninstall": [
+        "$qaacDir = $(appdir qaac $global)",
+        "if (Test-Path \"$qaacDir\") {",
+        "    Get-ChildItem -Path \"$qaacDir\\current\" -Filter \"QTFiles*\" | Remove-Item -Force -Recurse",
+        "}"
+    ],
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": [
-                    "https://github.com/AnimMouse/QTFiles/releases/download/v$version/QTfiles64.7z",
-                    "https://github.com/AnimMouse/QTFiles/releases/download/v$version/QTfiles64-msvc.7z"
-                ]
+                "url": "https://github.com/K3V1991/QuickTime-Files-for-qaac/releases/download/v$version/QT_v$version-x64.zip",
+                "extract_dir": "QT v$version (x64)"
             },
             "32bit": {
-                "url": [
-                    "https://github.com/AnimMouse/QTFiles/releases/download/v$version/QTfiles.7z",
-                    "https://github.com/AnimMouse/QTFiles/releases/download/v$version/QTfiles-msvc.7z"
-                ]
+                "url": "https://github.com/K3V1991/QuickTime-Files-for-qaac/releases/download/v$version/QT_v$version-x86.zip",
+                "extract_dir": "QT v$version (x86)"
             }
         }
     }


### PR DESCRIPTION
Please test this before merging, as I don't use qaac, I just use the codecs. Also with that being said, I think it might be a good idea to remove `depends` on this package, and maybe instead add it within `qaac.json` if you want that.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).