### PR TITLE
8bitdo-ultimate-software-v2: fix extract_dir

### DIFF
--- a/bucket/8bitdo-ultimate-software-v2.json
+++ b/bucket/8bitdo-ultimate-software-v2.json
@@ -5,7 +5,7 @@
     "license": "Freeware",
     "url": "https://download.8bitdo.cn/Ultimate-Software/8BitDo_Ultimate_Software_V2_Windows_V1.29.zip",
     "hash": "0e31b1daeb5c257b1ba7f295ebe2423eb85327cc5c19651607fcf734c13116b3",
-    "extract_dir": "8BitDo_Ultimate_Software_V2_V1.29",
+    "extract_dir": "8BitDo_Ultimate_Software_V2_Windows_V1.29",
     "shortcuts": [
         [
             "8BitDo Ultimate Software V2.exe",
@@ -18,6 +18,6 @@
     },
     "autoupdate": {
         "url": "https://download.8bitdo.cn/Ultimate-Software/8BitDo_Ultimate_Software_V2_Windows_V$version.zip",
-        "extract_dir": "8BitDo_Ultimate_Software_V2_V$version"
+        "extract_dir": "8BitDo_Ultimate_Software_V2_Windows_V$version"
     }
 }


### PR DESCRIPTION
Seem like 8bitdo updated sth in their builds, so changed manifest accordingly. Checked on my machine
